### PR TITLE
Follow upstream deprecation of Three.js for resourcePath

### DIFF
--- a/src/stories/loader/loader.stories.ts
+++ b/src/stories/loader/loader.stories.ts
@@ -24,7 +24,7 @@ const modelPath = 'https://raw.githubusercontent.com/makimenko/files/master/angu
       <atft-obj-loader
               model="${modelPath}/SampleArchitecture.obj"
               material="${modelPath}/SampleArchitecture.mtl"
-              texturePath="${modelPath}/"
+              resourcePath="${modelPath}/"
               translateX="-60" translateY="-40" translateZ="0.5">
           >
       </atft-obj-loader>


### PR DESCRIPTION
I've seen warnings on Travis: https://travis-ci.com/makimenko/angular-template-for-threejs/builds/129539691#L304:

> WARN: 'THREE.MTLLoader: .setTexturePath() has been renamed to .setResourcePath().'