### PR TITLE
Export AbstractModelLoader from atft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # dependencies
 /node_modules
+node_modules/
 
 # IDEs and editors
 /.idea

--- a/projects/atft/src/lib/object/loader/index.ts
+++ b/projects/atft/src/lib/object/loader/index.ts
@@ -1,3 +1,4 @@
 export * from './obj-loader.component';
 export * from './object-loader.component';
 export * from './svg-loader.component';
+export * from './abstract-model-loader';


### PR DESCRIPTION
Export AbstractModelLoader so that it can be used by consumer of atft library.