### PR TITLE
Add action for publishing on NPM

### DIFF
--- a/.github/workflows/publish-on-npm.yml
+++ b/.github/workflows/publish-on-npm.yml
@@ -1,0 +1,19 @@
+name: Publish on NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Add an action which publishes to NPM upon every new GitHub release we make.

@makimenko Before merging, you would need to add the NPM secret to the repo's settings: https://sergiodxa.com/static/articles/gh-secrets.png.

(Initial template copied from https://sergiodxa.com/articles/github-actions-npm-publish/.)